### PR TITLE
Fix Bandcamp eating page get requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ dependencies = [
     "beautifulsoup4 >= 4.12",
     "filetype >= 1.0",
     "requests >= 2.31",
-    "tqdm >= 4.66"
+    "tqdm >= 4.66",
+    "validator_collection >= 1.5"
 ]
 
 [build-system]

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 You'll need Python 3 to run `bc-art`. You can check if it's installed by running `python3 --version` or `python --version`. If you haven't got Python 3, you can download it from [python.org](https://www.python.org/downloads/) or your package manager.
 
+You will also need `curl`. You can check if it's installed by running `curl --version`. If you haven't got curl, you can download it from [curl.se](https://curl.se/download.html) or your package manager.
+
 Download the repository (click "Code" above, then "Download ZIP", or clone it with `git`). Then `cd` into the repository and run this:
 
 ```

--- a/src/bc_art/__init__.py
+++ b/src/bc_art/__init__.py
@@ -10,6 +10,7 @@ import sys
 from argparse import ArgumentParser
 from bs4 import BeautifulSoup as bs4
 from urllib.parse import urljoin, urlparse
+from validator_collection import validators
 
 signal.signal(signal.SIGINT, lambda x, y: sys.exit(1))
 
@@ -186,6 +187,7 @@ def normalize_name(string):
         return re.sub(r"[\\\\/:*?\"<>|\t]|\ +$", "-", string)
 
 def get_text(url):
+    url = validators.url(url)
     completed = subprocess.run(["curl", url], capture_output=True)
     return completed.stdout
 
@@ -193,6 +195,7 @@ def get_page(url):
     return bs4(get_text(url), features="html.parser")
 
 def get_stream(url):
+    url = validators.url(url)
     stream = requests.get(url, stream=True)
     stream.raise_for_status()
     return stream

--- a/src/bc_art/__init__.py
+++ b/src/bc_art/__init__.py
@@ -187,6 +187,9 @@ def normalize_name(string):
 def get_text(url):
     return requests.get(url).text
 
+def get_page(url):
+    return bs4(get_text(url), features="html.parser")
+
 def get_stream(url):
     stream = requests.get(url, stream=True)
     stream.raise_for_status()
@@ -217,7 +220,7 @@ async def process_url(url):
 async def process_discography(url):
     disco_name = extract_discography_from_url(url)
 
-    page = bs4(get_text(url), features="html.parser")
+    page = get_page(url)
     grid_items = page.findAll("li", class_="music-grid-item")
 
     for griditem in iter_tqdm(grid_items, desc=disco_name, unit="album"):
@@ -232,7 +235,7 @@ async def process_album(url, toplevel=True):
 
     await process_album_cover(url, seen)
 
-    page = bs4(get_text(url), features="html.parser")
+    page = get_page(url)
     tracks = page.findAll(itemprop="tracks") + page.findAll(class_="track_row_view")
 
     for track in iter_tqdm(tracks, desc=url.split("/")[-1], unit="track", leave=toplevel):
@@ -270,7 +273,7 @@ async def process_track(url, track_no=None, seen=None):
     await process_cover_download(image_url, out, seen)
 
 def process_album_track_page(url):
-    page = bs4(get_text(url), features="html.parser")
+    page = get_page(url)
     album_span = page.find("span", class_="fromAlbum")
     title = page.find("h2", class_="trackTitle").text.strip()
     image_url = page.find("a", class_="popupImage").get("href")

--- a/src/bc_art/__init__.py
+++ b/src/bc_art/__init__.py
@@ -184,6 +184,9 @@ def normalize_name(string):
     else:
         return re.sub(r"[\\\\/:*?\"<>|\t]|\ +$", "-", string)
 
+def get_text(url):
+    return requests.get(url).text
+
 def get_stream(url):
     stream = requests.get(url, stream=True)
     stream.raise_for_status()
@@ -214,7 +217,7 @@ async def process_url(url):
 async def process_discography(url):
     disco_name = extract_discography_from_url(url)
 
-    page = bs4(requests.get(url).text, features="html.parser")
+    page = bs4(get_text(url), features="html.parser")
     grid_items = page.findAll("li", class_="music-grid-item")
 
     for griditem in iter_tqdm(grid_items, desc=disco_name, unit="album"):
@@ -229,7 +232,7 @@ async def process_album(url, toplevel=True):
 
     await process_album_cover(url, seen)
 
-    page = bs4(requests.get(url).text, features="html.parser")
+    page = bs4(get_text(url), features="html.parser")
     tracks = page.findAll(itemprop="tracks") + page.findAll(class_="track_row_view")
 
     for track in iter_tqdm(tracks, desc=url.split("/")[-1], unit="track", leave=toplevel):
@@ -267,7 +270,7 @@ async def process_track(url, track_no=None, seen=None):
     await process_cover_download(image_url, out, seen)
 
 def process_album_track_page(url):
-    page = bs4(requests.get(url).text, features="html.parser")
+    page = bs4(get_text(url), features="html.parser")
     album_span = page.find("span", class_="fromAlbum")
     title = page.find("h2", class_="trackTitle").text.strip()
     image_url = page.find("a", class_="popupImage").get("href")

--- a/src/bc_art/__init__.py
+++ b/src/bc_art/__init__.py
@@ -4,6 +4,7 @@ import os
 import re
 import requests
 import signal
+import subprocess
 import sys
 
 from argparse import ArgumentParser
@@ -185,7 +186,8 @@ def normalize_name(string):
         return re.sub(r"[\\\\/:*?\"<>|\t]|\ +$", "-", string)
 
 def get_text(url):
-    return requests.get(url).text
+    completed = subprocess.run(["curl", url], capture_output=True)
+    return completed.stdout
 
 def get_page(url):
     return bs4(get_text(url), features="html.parser")

--- a/src/bc_art/__init__.py
+++ b/src/bc_art/__init__.py
@@ -184,8 +184,7 @@ def normalize_name(string):
     else:
         return re.sub(r"[\\\\/:*?\"<>|\t]|\ +$", "-", string)
 
-def get_stream(url, prev_url=None):
-    url = urljoin(prev_url, url)
+def get_stream(url):
     stream = requests.get(url, stream=True)
     stream.raise_for_status()
     return stream


### PR DESCRIPTION
Makes text-based get requests (now all funneled through `get_page()`, then `get_text()`) use a `curl` subprocess instead of the `requests` module. This is as simple and dumb as the solution gets: curl works and requests doesn't, so we are using curl.

`get_stream()` continues to work with requests, so we're leaving it as it is.

The readme notes that `curl` is now required. We already validated URLs at `process_url()`, but now we also validate it, using [`validator_collection`](https://github.com/insightindustry/validator-collection)'s [`validators.url()`](https://validator-collection.readthedocs.io/en/latest/validators.html#validator_collection.validators.url) function, at the point where the URL is actually consumed - i.e. inside `get_text()`. (And inside `get_stream()` too, for good measure.)

See discussion in [#software-support](https://discord.com/channels/749042497610842152/1153707535895908584/1272147072161943553) and in [#hsmusic-chat](https://discord.com/channels/749042497610842152/779895315750715422/1272154966026620999).